### PR TITLE
Add line deletion functionality

### DIFF
--- a/blockI.py
+++ b/blockI.py
@@ -23,19 +23,10 @@ class BlockI(pygame.sprite.Sprite):
 
         self.blocks2 = [
             [
-                None,
-            ],
-            [
                 BasicBlock(x, y + 48, color),
                 BasicBlock(x + 48, y + 48, color),
                 BasicBlock(x + 96, y + 48, color),
                 BasicBlock(x + 144, y + 48, color),
-            ],
-            [
-                None,
-            ],
-            [
-                None,
             ],
         ]
 
@@ -56,17 +47,10 @@ class BlockI(pygame.sprite.Sprite):
 
         self.blocks4 = [
             [
-                None,
-            ],
-            [None],
-            [
                 BasicBlock(x, y + 96, color),
                 BasicBlock(x + 48, y + 96, color),
                 BasicBlock(x + 96, y + 96, color),
                 BasicBlock(x + 144, y + 96, color),
-            ],
-            [
-                None,
             ],
         ]
 

--- a/main.py
+++ b/main.py
@@ -227,6 +227,22 @@ class Game:
                                 canTurnRight = False
                     self.rotation += 1
 
+    def deleteLine(self):
+        for i in range(len(self.game)):
+            deleteLine = True
+            for j in self.game[i]:
+                if j == None:
+                    deleteLine = False
+            if deleteLine:
+                for k in range(i, 0, -1):
+                    for l in range(len(self.game[k])):
+                        if self.game[k][l] != None:
+                            self.game[k][l].rect.y += 48
+                        self.game[k][l] = self.game[k - 1][l]
+        self.drawGame()
+        pygame.display.flip()
+        pygame.display.update()
+
     def drawBackgroundImages(self):
         self.screen.blit(self.background, (0, 0))
         self.screen.blit(self.gameFiled, (520, 0))
@@ -305,6 +321,7 @@ class Game:
                 self.speed -= 1
 
             self.refreshScreen()
+            self.deleteLine()
 
             if self.blockOnScreen == False:
                 self.createBlock()


### PR DESCRIPTION
This pull request adds a new feature to the game where lines can be deleted when they are completely filled with blocks. The `deleteLine` method has been implemented to check for full lines and remove them from the game grid. After deleting a line, the blocks above it are shifted down to fill the gap. This enhances the gameplay experience by allowing players to strategically clear lines and earn points.